### PR TITLE
Entfernt überflüssige Klammer aus dem Datenschema

### DIFF
--- a/Kontextmaterialien/Datenschema_Deutschland_Landkreise_COVID-19-Impfungen.json
+++ b/Kontextmaterialien/Datenschema_Deutschland_Landkreise_COVID-19-Impfungen.json
@@ -471,7 +471,6 @@
 		  "Anzahl": {
             "$ref": "#/definitions/impfereignisse"
           }
-          }
         }
       }
     }


### PR DESCRIPTION
Die Landkreise Version ist aufgrund einer überflüssigen Klammer keine gültige JSON Datei.
Dieses Pull Request sollte das beheben.